### PR TITLE
Fix fontforge attributes that must be strings

### DIFF
--- a/bdf2ttf/convert.py
+++ b/bdf2ttf/convert.py
@@ -25,10 +25,13 @@ def map_attributes(bdf, font):
     for attr_name in attr_map:
         attr_value = bdf[attr_name]
         if attr_value is not None:
+            if isinstance(attr_value, bytes):
+                attr_value = attr_value.decode()
+
             setattr(font, attr_map[attr_name], attr_value)
 
     fontname = compute_fontname(bdf)
-    font.fontname = fontname
+    font.fontname = fontname.decode()
 
 
 # Build the final font name


### PR DESCRIPTION
This broke in https://github.com/fontforge/fontforge/pull/4333.

Using strings should be backwards compatible with older FontForge versions.